### PR TITLE
Remove "Your comment is awaiting moderation" line after approving a comment

### DIFF
--- a/js/fv_tc.js
+++ b/js/fv_tc.js
@@ -9,6 +9,7 @@ function fv_tc_approve(id) {
             jQuery("#comment-body-"+id).children(":first").text('');
             jQuery("#comment-"+id+"-approve").remove();
             jQuery("#comment-"+id+"-unapproved").removeClass("tc_highlight");
+            jQuery("#comment-"+id).find("p.comment-awaiting-moderation").remove();
         }
     });
     return false;  


### PR DESCRIPTION
Hi,

This PR removes the `Your comment is awaiting moderation` line from the comment content after a comment is successfully approved.

Let me know if you have any questions.
