### PR TITLE
Add filter to 'Trash & Ban' link

### DIFF
--- a/fv-thoughtful-comments.php
+++ b/fv-thoughtful-comments.php
@@ -441,12 +441,16 @@ class fv_tc extends fv_tc_Plugin {
             $out .= $this->get_t_delete_thread($comment).' ';
           //}
           /*  If IP isn't banned  */
-          if(stripos(trim(get_option('blacklist_keys')),$comment->comment_author_IP)===FALSE) {
-              /*  Delete and ban  */
-              $out .= $this->get_t_delete_ban($comment);//.' | ';
-              /*  Delete thread and ban   */
-              //if($child>0)
-                  $out .= ' | '.$this->get_t_delete_thread_ban($comment);
+          if( stripos( trim( get_option( 'blacklist_keys' ) ), $comment->comment_author_IP ) === FALSE ) {
+		// Only show ban link if allowed.
+		if ( true === (bool) apply_filters( 'fv_show_trash_and_ban_link', true ) ) {
+			/*  Delete and ban  */
+			$out .= $this->get_t_delete_ban($comment);//.' | ';
+
+			/*  Delete thread and ban   */
+			//if($child>0)
+			$out .= ' | '.$this->get_t_delete_thread_ban($comment);
+		}
           } else {
               $out .= 'IP '.$comment->comment_author_IP.' ';
                             $out .= __('already banned!', 'fv_tc' );


### PR DESCRIPTION
Hi,

There are some cases where the `Trash & Ban` link may not be desireable as an option for users on the frontend.

This commit adds a filter to allow devs to toggle this link from being shown.  Let me know what you think.

I also noticed that the whitespace in the plugin is using spaces rather than tabs.  If you are interested, I can create another PR to normalize whitespace as [per WP standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation).
